### PR TITLE
Updates for Daffodil 3.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ version := "0.0.1"
 scalaVersion := "2.12.15"
  
 libraryDependencies ++= Seq(
-  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.2.0" % "test",
+  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.4.0" % "test",
   "junit" % "junit" % "4.13.2" % "test",
   "com.github.sbt" % "junit-interface" % "0.13.2" % "test"
 )

--- a/src/test/scala/com/mitre/bmp/TestMarbles.scala
+++ b/src/test/scala/com/mitre/bmp/TestMarbles.scala
@@ -1,14 +1,11 @@
 package com.mitre.bmp
 import org.junit.Test
-import org.apache.daffodil.tdml.DFDLTestSuite
-import org.apache.daffodil.util.Misc
+import org.apache.daffodil.tdml.Runner
 
 object TestMarbles {
-  val tdmlFile = "com/mitre/bmp/Marbles/Marbles.tdml"
-  val validateTDML = true
-  val validateDFDLSchema = true
-  lazy val runner = new DFDLTestSuite(Misc.getRequiredResource(tdmlFile), validateTDML, validateDFDLSchema)
-  runner.setCheckAllTopLevel(true)
+  val testDir = "com/mitre/bmp/Marbles"
+  val tdmlFile = "Marbles.tdml"
+  lazy val runner = Runner(testDir, tdmlFile, compileAllTopLevel = true)
 }
 
 class TestMarbles {


### PR DESCRIPTION
Pin to Daffodil version 3.4.0 and update the test to use Runner instead of DFDLTestSuite.